### PR TITLE
feature: updates and drop terminal-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Initial development and testing was performed with:
 ## Installation
 
 1. Download and unzip the package:
-   [Markdownlint-cli2.bbpackage_v0.9.3.zip](https://github.com/mobilemind/BBEdit-Markdownlint-cli2/raw/main/dist/Markdownlint-cli2.bbpackage_v0.9.3.zip)
-2. Double–click the Markdownlint-cli2.bbpackage_v0.9.2.bbpackage, BBEdit will
-   prompt you to install (or update), and restart.
+   [Markdownlint-cli2.bbpackage_v0.9.5.zip](https://github.com/mobilemind/BBEdit-Markdownlint-cli2/raw/main/dist/Markdownlint-cli2.bbpackage_v0.9.5.zip)
+2. Double–click the Markdownlint-cli2.bbpackage, BBEdit will prompt you to
+   install (or update), and restart.
 
 The package file will be copied to the Packages directory in BBEdit’s
 Application Support directory. Delete it from here should you wish uninstall
@@ -63,9 +63,6 @@ palette where you can assign your own keyboard shortcut.
 Open a Markdown file in BBEdit and trigger **Markdownlint-cli2**. A BBEdit
 results window should open listing any Markdownlint-cli2 feedback. If there
 are no warnings or errors to report nothing will happen.
-
-If [terminal-notifier](https://github.com/julienXX/terminal-notifier) is installed,
-on the Mac running **Markdownlint-cli2**, the behavior changes slightly.
 
 - If markdownlint-cli2 finds no issues, a macOS notification is posted (assuming
   Do Not Disturb is off) and the default alert sound plays. The message title

--- a/makefile
+++ b/makefile
@@ -11,6 +11,8 @@ INFO_PATH = $(PWD)/src/Info
 VERSION = $(shell defaults read $(INFO_PATH) CFBundleShortVersionString)
 ZIP = ./$(PKGNAME)_v$(VERSION).zip
 
+.SUFFIXES:
+
 .DEFAULT: all
 
 .PHONY: all clean install
@@ -28,19 +30,21 @@ install: all
 build: $(PKG) $(ZIP)
 
 dist: all
-	# update the link to the dist file
-	perl -i -pe "s/$(PKGNAME)_v.*?\.zip/$(PKGNAME)_v$(VERSION).zip/g" README.md
-	# spellcheck things if cspell is installed
-	if hash cspell > /dev/null 2>&1 && [ -s "$HOME/.cspell/.cspell.json" ] ; then \
-		cspell lint -c "$HOME/.cspell/.cspell.json" README.md LICENSE src/Scripts/*.sh ; \
+	@# Update the link in README.MD to the dist file to v$(VERSION)
+	perl -i -pe "s/$(PKGNAME)_v[.0-9]*?\.zip/$(PKGNAME)_v$(VERSION).zip/g" README.md
+	@if hash cspell > /dev/null 2>&1 && [ -s "$(HOME)/.cspell/.cspell.json" ] ; then \
+		echo 'cspell lint ~/.cspell/.cspell.json README.md LICENSE src/Scripts/*.sh' && \
+		cspell lint -c "$(HOME)/.cspell/.cspell.json" README.md LICENSE src/Scripts/*.sh ; \
 	fi
 	@echo
 	@echo "Remember to commit & push changes, plus 'git tag v$(VERSION) && git push --tags' AND make a release."
 
 $(PKG):
-	# shellcheck scripts if it's available
-	if hash shellcheck > /dev/null 2>&1 ; then shellcheck -s sh src/Scripts/*.sh ; fi
-	# format check the README.md (verifies that 'npx' & 'markdownlint-cli2' are installed)
+	@if hash shellcheck > /dev/null 2>&1 ; then \
+		echo 'shellcheck -s sh src/Scripts/*.sh' && \
+		shellcheck -s sh src/Scripts/*.sh ; \
+	fi
+	@# format check the README.md (verifies that 'npx' & 'markdownlint-cli2' are installed)
 	npx markdownlint-cli2 README.md
 	mkdir -p $(CONTENTS_DIR)
 	cp README.md $(PKG)/.

--- a/src/Info.plist
+++ b/src/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>0.9.3</string>
+	<string>0.9.5</string>
 </dict>
 </plist>

--- a/src/Scripts/Markdownlint-cli2.sh
+++ b/src/Scripts/Markdownlint-cli2.sh
@@ -3,30 +3,30 @@
 SHORTNAME="$(basename "$BB_DOC_PATH")"
 SCRIPT="$(basename "$0" '.sh')"
 
-NOTIFY() { # $1=TITLE , $2=MESSAGE, $3=SOUND
-	hash terminal-notifier >/dev/null 2>&1 && \
-			(nohup terminal-notifier -title "$1" -message "$2" -sound "$3" >/dev/null 2>&1 &)
-}
-
 # check for npx
 if ! hash npx > /dev/null 2>&1 ; then
-	NOTIFY "SCRIPT: ERROR" "npx not installed. Try installing it with 'npm install -g npx' and/or adding it to your PATH variable. Then restart BBedit." 'sosumi'
+	osascript -e "display notification \"npx not found. Try installing npm. Then restart BBedit.\" with title \"$SCRIPT: ERROR\" subtitle \"\" sound name \"sosumi\""
 	echo "ERROR: markdownlint-cli2 not installed. Try installing it with 'npm install -g npx' and/or adding it to your PATH variable. Then restart BBedit."
 	exit 1
 fi
 
 # check for markdownlint-cli2
 if ! hash markdownlint-cli2 > /dev/null 2>&1 ; then
-	NOTIFY "SCRIPT: ERROR" "markdownlint-cli2 not installed. Try installing it with 'npm install -g markdownlint-cli2' then restart BBedit." 'sosumi'
+	osascript -e "display notification \"markdownlint-cli2 not installed. Try installing it with 'npm install -g markdownlint-cli2'. Then restart BBedit.\" with title \"$SCRIPT: ERROR\" subtitle \"\" sound name \"sosumi\""
 	echo "ERROR: markdownlint-cli2 not installed. Try installing it with 'npm install -g markdownlint-cli2' then restart Terminal."
 	exit 1
 fi
 
 # confirm there is a non-empty file to check
 if [ ! -s "${BB_DOC_PATH}" ] ; then
-	NOTIFY "SCRIPT: ERROR" "\"${BB_DOC_PATH}\" not found or empty." 'sosumi'
+	osascript -e "display notification \"BB_DOC_PATH not found, or empty:\" & return & \"${BB_DOC_PATH}\" with title \"$SCRIPT: ERROR\" subtitle \"\" sound name \"sosumi\""
 	echo "ERROR: File '${BB_DOC_PATH}' from BBEdit was not found or empty."
 	exit 1
+fi
+
+# if BB_DOC_PATH is within $BB_DOC_WORKSPACE_ROOT, then make path more readable
+if [ -n "$BB_DOC_WORKSPACE_ROOT" ] && [ "${BB_DOC_PATH#*"$BB_DOC_WORKSPACE_ROOT"}" != "$BB_DOC_PATH" ]; then
+	cd "$BB_DOC_WORKSPACE_ROOT" > /dev/null 2>&1 || true
 fi
 
 RESULTS="$(npx markdownlint-cli2 "${BB_DOC_PATH}" 2>&1 || echo '')"
@@ -34,7 +34,7 @@ RESULTS="$(npx markdownlint-cli2 "${BB_DOC_PATH}" 2>&1 || echo '')"
 # check results
 if [ -z "$RESULTS" ] ; then
 	# no results is an error, there should at least be summary info
-	NOTIFY "SCRIPT: ERROR" "No results from 'npx markdownlint-cli2 \"${BB_DOC_PATH}\". Check configuration." 'sosumi'
+	osascript -e "display notification \"No results from 'npx markdownlint-cli2 \" & quote & \"${BB_DOC_PATH}\" & quote & \"'. Check configuration.\" with title \"$SCRIPT: ERROR\" subtitle \"\" sound name \"sosumi\""
 	echo "SCRIPT: ERROR: No results from 'npx markdownlint-cli2 \"${BB_DOC_PATH}\". Check configuration."
 	exit 1
 fi
@@ -45,16 +45,18 @@ fi
 # shellcheck disable=SC2143
 if [ -z "$(echo "$RESULTS" | grep -Ev 'markdownlint-cli2 v[0-9]+\.[0-9]+\.[0-9]+ \(markdownlint v[0-9]+\.[0-9]+\.[0-9]+\)')" ] || echo "$RESULTS" | grep -Fq 'Summary: 0 error(s)' > /dev/null 2>&1 ; then
 	# no errors, indicate success with terminal notifier and default sound before exiting
-	NOTIFY "$SCRIPT $SHORTNAME" 'No errors.' 'default'
+	osascript -e "display notification \"No errors.\" with title \"$SCRIPT: $SHORTNAME\" subtitle \"\" sound name \"default\""
 	exit 0
 fi
 
 # trim summary or version info from the top to pass bbresults a clean list of issues
 RESULTS="$(echo "$RESULTS" | sed '/^markdownlint-cli2 v/d; /^Linting: /,/^Summary: /d')"
-echo "RESULTS: $RESULTS"
 
 # set BBEdit results RegEx pattern for markdownlint-cli2 default output
 PATTERN='(?P<file>.+?):(?P<line>\d+)?(:(?P<col>\d+))? (?P<type>\S+) (?P<msg>.*)$'
+
+# to debug, uncomment the line below and check the BBEdit "Unix Script Output.log" file.
+# echo "$RESULTS"
 
 # send results back to BBEdit (no need to notify, since Results browser appears)
 echo "$RESULTS" | bbresults --pattern "$PATTERN"


### PR DESCRIPTION
feature: updates and drop terminal-notifier

* chore(makefile): empty ".SUFFIXES:" for speed; clearer conditionals
* feat(Markdownlint-cli2): use osascript & drop terminal-notifier; other refinements
* feat: bump version & prepare for dist
